### PR TITLE
feat: mobile optimization, lobby share button, and mobile e2e tests

### DIFF
--- a/e2e/mobile-game.spec.js
+++ b/e2e/mobile-game.spec.js
@@ -1,0 +1,613 @@
+/**
+ * Mobile Browser E2E Tests
+ *
+ * These tests verify mobile-specific functionality and gameplay on mobile viewports.
+ * They run against both Pixel 5 (Android Chrome) and iPhone 12 (Mobile Safari)
+ * as configured in playwright.config.js.
+ *
+ * Test suites:
+ *   1. Lobby share button — verifies the share/copy-link button renders and
+ *      triggers the correct behaviour (Web Share API or clipboard copy).
+ *   2. Mobile game board — verifies the responsive board layout on narrow screens.
+ *   3. Full mobile game flow — 4-player game completed on a mobile viewport,
+ *      confirming all touch-based interactions work end-to-end.
+ *
+ * Prerequisites (started automatically by playwright.config.js webServer):
+ *   Backend  → gunicorn (http://localhost:5000)
+ *   Frontend → vite dev  (http://localhost:5173)
+ */
+
+import { test, expect } from '@playwright/test';
+
+// ─── Constants ────────────────────────────────────────────────────────────────
+
+const FRONTEND_URL = process.env.FRONTEND_URL || 'http://localhost:5173';
+const BACKEND_URL = process.env.BACKEND_URL || 'http://localhost:5000';
+const BACKEND_API_URL = `${BACKEND_URL}/api`;
+
+const MAX_TURNS = 25;
+const TURN_END_POLL_TIMEOUT_MS = 15_000;
+
+// ─── Helpers (shared with full-game.spec.js) ──────────────────────────────────
+
+async function waitForGameState(
+  request,
+  lobbyId,
+  userId,
+  condition,
+  timeout = 15_000,
+) {
+  const deadline = Date.now() + timeout;
+  while (Date.now() < deadline) {
+    const resp = await request.get(
+      `${BACKEND_API_URL}/${lobbyId}?user_id=${userId}`,
+    );
+    if (resp.ok()) {
+      const state = await resp.json();
+      if (condition(state)) return state;
+    }
+    await new Promise((r) => setTimeout(r, 400));
+  }
+  throw new Error(`waitForGameState timed out after ${timeout} ms`);
+}
+
+async function waitForLobbyState(
+  request,
+  lobbyId,
+  condition,
+  timeout = 10_000,
+) {
+  const deadline = Date.now() + timeout;
+  while (Date.now() < deadline) {
+    const resp = await request.get(`${BACKEND_API_URL}/lobby/${lobbyId}`);
+    if (resp.ok()) {
+      const lobby = await resp.json();
+      if (condition(lobby)) return lobby;
+    }
+    await new Promise((r) => setTimeout(r, 400));
+  }
+  throw new Error(`waitForLobbyState timed out after ${timeout} ms`);
+}
+
+// ─── Suite 1: Lobby share button ──────────────────────────────────────────────
+
+test.describe('Mobile — Lobby share button', () => {
+  test.setTimeout(60_000);
+
+  test('share button renders and copies link to clipboard on mobile', async ({
+    browser,
+    request,
+  }) => {
+    // Grant clipboard-write permission so the fallback copy path works even
+    // when navigator.share is unavailable in the test browser.
+    const ctx = await browser.newContext({
+      permissions: ['clipboard-read', 'clipboard-write'],
+    });
+
+    const page = await ctx.newPage();
+
+    try {
+      // Create a lobby
+      await page.goto(`${FRONTEND_URL}/game?disableWebex=true`);
+      await page.getByLabel('Game Name').fill('Mobile Share Test');
+      await page.getByLabel('Your Display Name').fill('MobileHost');
+      const webexCheckbox = page.getByLabel('Enable Webex Integration');
+      if (await webexCheckbox.isChecked()) {
+        await webexCheckbox.uncheck();
+      }
+      await page.getByRole('button', { name: 'Create Game' }).click();
+      await page.waitForURL(`${FRONTEND_URL}/game/**`, { timeout: 10_000 });
+
+      const lobbyId = page.url().split('/game/')[1].split('?')[0];
+      await page.waitForSelector('text=Mobile Share Test', { timeout: 10_000 });
+
+      // The share button should always be visible in the lobby
+      const shareBtn = page.getByTestId('share-lobby-button');
+      await expect(shareBtn).toBeVisible({ timeout: 5_000 });
+
+      // On devices without navigator.share the button label is "Copy Lobby Link"
+      // On devices with navigator.share it is "Share Lobby".
+      // In Playwright's headless Chromium/WebKit, navigator.share is typically
+      // undefined, so we expect the clipboard-copy path.
+      const btnText = await shareBtn.innerText();
+      const isNativeShare = btnText.trim() === 'Share Lobby';
+
+      if (!isNativeShare) {
+        // Clipboard fallback path: clicking should copy the URL and show Snackbar
+        await shareBtn.click();
+
+        // Confirm the success snackbar appears
+        await expect(
+          page.getByText('Lobby link copied to clipboard!'),
+        ).toBeVisible({ timeout: 5_000 });
+
+        // Confirm the clipboard contains the lobby URL
+        const clipText = await page.evaluate(() =>
+          navigator.clipboard.readText(),
+        );
+        expect(clipText).toContain(lobbyId);
+      } else {
+        // Native share path: just verify the button is tappable without error
+        // (We cannot fully automate the OS share sheet, so clicking is the best
+        //  we can do; if no error is thrown the test passes.)
+        await expect(shareBtn).toBeEnabled();
+      }
+
+      await waitForLobbyState(request, lobbyId, (l) => l !== null, 5_000);
+    } finally {
+      await ctx.close();
+    }
+  });
+});
+
+// ─── Suite 2: Mobile game board layout ────────────────────────────────────────
+
+test.describe('Mobile — Game board responsive layout', () => {
+  test.setTimeout(3 * 60_000);
+
+  test('game board renders in 2-column layout on mobile viewport', async ({
+    browser,
+    request,
+  }) => {
+    // Spin up a 2-player game (minimum viable) so we can inspect the board.
+    const ctx1 = await browser.newContext();
+    const ctx2 = await browser.newContext();
+
+    try {
+      const page1 = await ctx1.newPage(); // Host — Team 1 Hacker
+      const page2 = await ctx2.newPage(); // Player 2 — Team 2 Hacker
+
+      // Create lobby
+      await page1.goto(`${FRONTEND_URL}/game?disableWebex=true`);
+      await page1.getByLabel('Game Name').fill('Mobile Layout Test');
+      await page1.getByLabel('Your Display Name').fill('HostMobile');
+      const checkbox = page1.getByLabel('Enable Webex Integration');
+      if (await checkbox.isChecked()) await checkbox.uncheck();
+      await page1.getByRole('button', { name: 'Create Game' }).click();
+      await page1.waitForURL(`${FRONTEND_URL}/game/**`, { timeout: 10_000 });
+
+      const lobbyId = page1.url().split('/game/')[1].split('?')[0];
+      await page1.waitForSelector('text=Mobile Layout Test', {
+        timeout: 10_000,
+      });
+
+      // Join with second player
+      await page2.goto(`${FRONTEND_URL}/game/${lobbyId}?disableWebex=true`);
+      await page2.waitForSelector('text=Join Lobby', { timeout: 10_000 });
+      await page2.getByLabel('Enter your display name').fill('Player2Mobile');
+      await page2.getByRole('button', { name: 'Join Lobby' }).click();
+      await page2.waitForSelector('text=Mobile Layout Test', {
+        timeout: 10_000,
+      });
+
+      await page1.waitForTimeout(1_000);
+
+      // Fetch participants
+      const lobby = await waitForLobbyState(
+        request,
+        lobbyId,
+        (l) => l.participants.length === 2,
+        15_000,
+      );
+
+      const host = lobby.participants.find((p) => p.display_name === 'HostMobile');
+      const p2 = lobby.participants.find(
+        (p) => p.display_name === 'Player2Mobile',
+      );
+
+      // Assign hackers
+      await page1.locator('button:has-text("Become Hacker")').click();
+      await page1.waitForSelector('button:has-text("Become AI Agent")', {
+        timeout: 5_000,
+      });
+      await page2.locator('button:has-text("Become Hacker")').click();
+      await page2.waitForSelector('button:has-text("Become AI Agent")', {
+        timeout: 5_000,
+      });
+
+      // Ready up
+      for (const page of [page1, page2]) {
+        await page.getByRole('button', { name: 'Not Ready' }).click();
+      }
+
+      // Force-start (2 players may not satisfy the balance requirement)
+      await page1.waitForSelector(
+        'button:has-text("Launch Operation"), button:has-text("Override Protocols")',
+        { timeout: 10_000 },
+      );
+      const launchBtn = page1.getByRole('button', { name: 'Launch Operation' });
+      if (await launchBtn.isVisible()) {
+        await launchBtn.click();
+      } else {
+        await page1
+          .getByRole('button', { name: 'Override Protocols' })
+          .click();
+        await page1.getByRole('button', { name: 'Execute Override' }).click();
+      }
+
+      await Promise.all([
+        page1.waitForSelector('text=Game In Progress', { timeout: 15_000 }),
+        page2.waitForSelector('text=Game In Progress', { timeout: 15_000 }),
+      ]);
+
+      // ── Verify board layout ─────────────────────────────────────────────────
+      // The viewport is already mobile-sized (set by the Playwright device
+      // config for this project).  Check that card tiles are laid out in
+      // 2 columns by measuring their bounding boxes.
+
+      // Wait for at least one card tile to appear (they're rendered as Paper
+      // elements containing the word text).
+      const boardPaper = page1.locator('[class*="MuiPaper"]').filter({
+        has: page1.locator('text=Game Board'),
+      });
+      await expect(boardPaper).toBeVisible({ timeout: 10_000 });
+
+      // Collect the x-positions of the first 4 card tiles.
+      // In a 2-column layout xs={6}, cards in the same row share x-positions
+      // that differ by roughly half the viewport width, and 2 columns means
+      // only 2 distinct x values among the first 4 tiles.
+      const cardTiles = page1
+        .locator('[class*="MuiPaper-root"]')
+        .filter({ hasNot: page1.locator('h6') });
+
+      const count = await cardTiles.count();
+      expect(count).toBeGreaterThanOrEqual(4);
+
+      const firstFourBoxes = await Promise.all(
+        [0, 1, 2, 3].map((i) => cardTiles.nth(i).boundingBox()),
+      );
+
+      // Ensure all boxes were found
+      for (const box of firstFourBoxes) {
+        expect(box).not.toBeNull();
+      }
+
+      // On mobile (2-column), tile [0] and tile [2] should be in the same
+      // column (same x), and tile [1] and tile [3] in the other column.
+      const col0x = firstFourBoxes[0].x;
+      const col1x = firstFourBoxes[1].x;
+      expect(Math.abs(firstFourBoxes[2].x - col0x)).toBeLessThan(5);
+      expect(Math.abs(firstFourBoxes[3].x - col1x)).toBeLessThan(5);
+      // The two columns should be meaningfully apart
+      expect(Math.abs(col1x - col0x)).toBeGreaterThan(50);
+
+      console.log('[mobile-layout] 2-column board layout confirmed on mobile viewport');
+
+      // Clean up: end the game via the host
+      await request.post(`${BACKEND_API_URL}/lobby/${lobbyId}/end_game`, {
+        data: { user_id: host.id },
+      });
+    } finally {
+      await ctx1.close();
+      await ctx2.close();
+    }
+  });
+});
+
+// ─── Suite 3: Full mobile game flow ───────────────────────────────────────────
+
+test.describe('Mobile — Full 4-player game on mobile viewport', () => {
+  // Same generous budget as the desktop full-game test
+  test.setTimeout(5 * 60_000);
+
+  test('four players complete a game on a mobile viewport', async ({
+    browser,
+    request,
+  }) => {
+    const ctx1 = await browser.newContext();
+    const ctx2 = await browser.newContext();
+    const ctx3 = await browser.newContext();
+    const ctx4 = await browser.newContext();
+
+    try {
+      const page1 = await ctx1.newPage(); // Alice  — Host, Team 1 Hacker
+      const page2 = await ctx2.newPage(); // Bob    — Team 2 Hacker
+      const page3 = await ctx3.newPage(); // Charlie — Team 1 AI Agent
+      const page4 = await ctx4.newPage(); // Diana   — Team 2 AI Agent
+
+      // ── PHASE 1: Alice creates the lobby ─────────────────────────────────
+      await test.step('Alice creates the lobby (mobile)', async () => {
+        await page1.goto(`${FRONTEND_URL}/game?disableWebex=true`);
+        await page1.getByLabel('Game Name').fill('Mobile Game Test');
+        await page1.getByLabel('Your Display Name').fill('AliceMobile');
+        const webexCheckbox = page1.getByLabel('Enable Webex Integration');
+        if (await webexCheckbox.isChecked()) {
+          await webexCheckbox.uncheck();
+        }
+        await page1.getByRole('button', { name: 'Create Game' }).click();
+        await page1.waitForURL(`${FRONTEND_URL}/game/**`, { timeout: 10_000 });
+      });
+
+      const lobbyId = page1.url().split('/game/')[1].split('?')[0];
+      console.log(`[mobile] Lobby created: ${lobbyId}`);
+
+      await page1.waitForSelector('text=Mobile Game Test', { timeout: 10_000 });
+
+      // ── PHASE 2: Other players join ───────────────────────────────────────
+      const joinLobby = async (page, displayName) => {
+        await page.goto(`${FRONTEND_URL}/game/${lobbyId}?disableWebex=true`);
+        await page.waitForSelector('text=Join Lobby', { timeout: 10_000 });
+        await page.getByLabel('Enter your display name').fill(displayName);
+        await page.getByRole('button', { name: 'Join Lobby' }).click();
+        await page.waitForSelector('text=Mobile Game Test', { timeout: 10_000 });
+      };
+
+      await test.step('Bob joins (mobile)', () => joinLobby(page2, 'BobMobile'));
+      await test.step('Charlie joins (mobile)', () =>
+        joinLobby(page3, 'CharlieMobile'));
+      await test.step('Diana joins (mobile)', () =>
+        joinLobby(page4, 'DianaMobile'));
+
+      await page1.waitForTimeout(1_000);
+
+      const initialLobby = await waitForLobbyState(
+        request,
+        lobbyId,
+        (l) => l.participants.length === 4,
+        15_000,
+      );
+
+      const findP = (name) =>
+        initialLobby.participants.find((p) => p.display_name === name);
+
+      const alice = findP('AliceMobile');
+      const bob = findP('BobMobile');
+      const charlie = findP('CharlieMobile');
+      const diana = findP('DianaMobile');
+
+      // ── PHASE 3: Share button is visible on mobile lobby ──────────────────
+      await test.step('Share button is visible in the mobile lobby', async () => {
+        await expect(
+          page1.getByTestId('share-lobby-button'),
+        ).toBeVisible({ timeout: 5_000 });
+        console.log('[mobile] Share lobby button confirmed visible');
+      });
+
+      // ── PHASE 4: Assign hackers ───────────────────────────────────────────
+      await test.step('Alice becomes Team 1 Hacker (mobile)', async () => {
+        await page1.locator('button:has-text("Become Hacker")').click();
+        await page1.waitForSelector('button:has-text("Become AI Agent")', {
+          timeout: 5_000,
+        });
+      });
+
+      await test.step('Bob becomes Team 2 Hacker (mobile)', async () => {
+        await page2.locator('button:has-text("Become Hacker")').click();
+        await page2.waitForSelector('button:has-text("Become AI Agent")', {
+          timeout: 5_000,
+        });
+      });
+
+      // ── PHASE 5: All players ready ────────────────────────────────────────
+      await test.step('All four players mark ready (mobile)', async () => {
+        for (const page of [page1, page2, page3, page4]) {
+          await page.getByRole('button', { name: 'Not Ready' }).click();
+        }
+        await waitForLobbyState(
+          request,
+          lobbyId,
+          (l) => l.participants.every((p) => p.ready),
+          10_000,
+        );
+      });
+
+      // ── PHASE 6: Alice starts the game ────────────────────────────────────
+      await test.step('Alice launches the game (mobile)', async () => {
+        await page1.waitForSelector(
+          'button:has-text("Launch Operation"), button:has-text("Override Protocols")',
+          { timeout: 10_000 },
+        );
+
+        const launchBtn = page1.getByRole('button', { name: 'Launch Operation' });
+        if (await launchBtn.isVisible()) {
+          await launchBtn.click();
+        } else {
+          await page1
+            .getByRole('button', { name: 'Override Protocols' })
+            .click();
+          await page1.getByRole('button', { name: 'Execute Override' }).click();
+        }
+
+        await Promise.all([
+          page1.waitForSelector('text=Game In Progress', { timeout: 15_000 }),
+          page2.waitForSelector('text=Game In Progress', { timeout: 15_000 }),
+          page3.waitForSelector('text=Game In Progress', { timeout: 15_000 }),
+          page4.waitForSelector('text=Game In Progress', { timeout: 15_000 }),
+        ]);
+        console.log('[mobile] Game started on all four pages');
+      });
+
+      // ── PHASE 7: Verify mobile board layout ───────────────────────────────
+      await test.step('Board renders in 2-column layout on mobile', async () => {
+        // The Game Board paper is visible
+        await expect(page3.getByText('Game Board')).toBeVisible({
+          timeout: 10_000,
+        });
+
+        // Viewport width for the device under test
+        const viewportWidth = page3.viewportSize()?.width ?? 390;
+
+        // Gather bounding boxes of the first 4 grid cells containing card tiles.
+        // We look for Paper elements that are children of the board Grid — they
+        // contain a single Typography with the card word.
+        const cardSelector =
+          '[class*="MuiGrid-item"] [class*="MuiPaper-root"]';
+        await page3.waitForSelector(cardSelector, { timeout: 10_000 });
+        const allCards = page3.locator(cardSelector);
+        const cardCount = await allCards.count();
+        expect(cardCount).toBeGreaterThanOrEqual(4);
+
+        const boxes = await Promise.all(
+          [0, 1, 2, 3].map((i) => allCards.nth(i).boundingBox()),
+        );
+        for (const box of boxes) {
+          expect(box).not.toBeNull();
+        }
+
+        // In a 2-column layout, each card should be roughly half the viewport
+        // wide (minus gaps/padding).
+        const cardWidth = boxes[0].width;
+        expect(cardWidth).toBeLessThan(viewportWidth * 0.6);
+        expect(cardWidth).toBeGreaterThan(viewportWidth * 0.3);
+
+        // Cards in the same column share the same x coordinate.
+        expect(Math.abs(boxes[0].x - boxes[2].x)).toBeLessThan(5);
+        expect(Math.abs(boxes[1].x - boxes[3].x)).toBeLessThan(5);
+
+        console.log(
+          `[mobile] Board layout: cardWidth=${cardWidth.toFixed(0)}px, viewportWidth=${viewportWidth}px`,
+        );
+      });
+
+      // ── PHASE 8: Game loop on mobile ──────────────────────────────────────
+      const teamConfig = {
+        team1: {
+          hackerPage: page1,
+          memberPage: page3,
+          hackerId: alice.id,
+          memberId: charlie.id,
+          cardType: 'team1_card',
+          label: 'Team 1 (AliceMobile hacks, CharlieMobile guesses)',
+        },
+        team2: {
+          hackerPage: page2,
+          memberPage: page4,
+          hackerId: bob.id,
+          memberId: diana.id,
+          cardType: 'team2_card',
+          label: 'Team 2 (BobMobile hacks, DianaMobile guesses)',
+        },
+      };
+
+      let gameOver = false;
+      let winner = null;
+
+      for (let turn = 1; turn <= MAX_TURNS && !gameOver; turn++) {
+        const preKeywordState = await waitForGameState(
+          request,
+          lobbyId,
+          alice.id,
+          (s) => s.game_phase === 'keyword_entry' || s.game_over,
+          20_000,
+        );
+
+        if (preKeywordState.game_over) {
+          gameOver = true;
+          winner = preKeywordState.winner;
+          console.log(`[mobile] Game ended before turn ${turn}. Winner: ${winner}`);
+          break;
+        }
+
+        const activeTeam = preKeywordState.active_team;
+        const cfg = teamConfig[activeTeam];
+        console.log(`[mobile] Turn ${turn}: ${cfg.label} — keyword_entry`);
+
+        // Hacker submits keyword
+        await test.step(`Mobile turn ${turn}: ${activeTeam} hacker submits keyword`, async () => {
+          const { hackerPage } = cfg;
+          await hackerPage.waitForSelector(
+            'input[placeholder*="single word"]:not([disabled])',
+            { timeout: 10_000 },
+          );
+          await hackerPage.getByLabel('Keyword').fill(`CLUE${turn}`);
+          await hackerPage.getByRole('button', { name: 'Send' }).click();
+        });
+
+        const guessingState = await waitForGameState(
+          request,
+          lobbyId,
+          cfg.hackerId,
+          (s) => s.game_phase === 'team_guessing' || s.game_over,
+          10_000,
+        );
+
+        if (guessingState.game_over) {
+          gameOver = true;
+          winner = guessingState.winner;
+          break;
+        }
+
+        const correctCard = guessingState.board.find(
+          (c) => !c.revealed && c.type === cfg.cardType,
+        );
+
+        if (!correctCard) {
+          console.log(`[mobile] No unrevealed ${cfg.cardType} cards left.`);
+          break;
+        }
+
+        console.log(
+          `[mobile] Turn ${turn}: ${cfg.label} guessing "${correctCard.word}"`,
+        );
+
+        // AI Agent taps the card and submits — same flow as desktop but on a
+        // mobile viewport.
+        await test.step(`Mobile turn ${turn}: ${activeTeam} AI agent taps "${correctCard.word}"`, async () => {
+          const { memberPage } = cfg;
+          await memberPage.waitForSelector(
+            "text=Select words that match your Hacker's keyword",
+            { timeout: 10_000 },
+          );
+
+          // tap() is the mobile-idiomatic way to interact with elements
+          await memberPage
+            .getByText(correctCard.word, { exact: true })
+            .tap();
+
+          await memberPage.waitForSelector('button:has-text("Submit Guess")', {
+            timeout: 5_000,
+          });
+          await memberPage
+            .getByRole('button', { name: /Submit Guess/ })
+            .tap();
+        });
+
+        const postTurnState = await waitForGameState(
+          request,
+          lobbyId,
+          alice.id,
+          (s) => s.game_phase === 'keyword_entry' || s.game_over,
+          TURN_END_POLL_TIMEOUT_MS,
+        );
+
+        if (postTurnState.game_over) {
+          gameOver = true;
+          winner = postTurnState.winner;
+          console.log(`[mobile] Game over after turn ${turn}. Winner: ${winner}`);
+          break;
+        }
+      }
+
+      // ── PHASE 9: Assertions ───────────────────────────────────────────────
+      expect(
+        gameOver,
+        'Mobile game should have ended before MAX_TURNS',
+      ).toBe(true);
+      expect(['team1', 'team2'], 'Winner must be a valid team').toContain(winner);
+
+      const finalResp = await request.get(
+        `${BACKEND_API_URL}/${lobbyId}?user_id=${alice.id}`,
+      );
+      const finalState = await finalResp.json();
+
+      expect(finalState.game_over).toBe(true);
+      expect(finalState.winner).toBe(winner);
+
+      const winnerRemaining = finalState.team_data[winner]?.remaining_cards;
+      expect(winnerRemaining, "Winner's remaining cards should be 0").toBe(0);
+
+      for (const page of [page1, page2, page3, page4]) {
+        await expect(page.getByText('Game In Progress')).toBeVisible({
+          timeout: 5_000,
+        });
+      }
+
+      console.log(`[mobile] All assertions passed. Winner: ${winner}`);
+    } finally {
+      await ctx1.close();
+      await ctx2.close();
+      await ctx3.close();
+      await ctx4.close();
+    }
+  });
+});

--- a/frontend/src/components/GameBoard.jsx
+++ b/frontend/src/components/GameBoard.jsx
@@ -117,7 +117,7 @@ const GameTile = ({
         elevation={3}
         onClick={() => isSelectable && onCardSelect(card.id)}
         sx={{
-          height: 80,
+          height: { xs: 56, sm: 80 },
           display: 'flex',
           alignItems: 'center',
           justifyContent: 'center',
@@ -126,15 +126,27 @@ const GameTile = ({
           border: border,
           cursor: isSelectable ? 'pointer' : 'default',
           transition: 'all 0.2s ease',
+          // Larger touch target on mobile
+          touchAction: 'manipulation',
           '&:hover': isSelectable
             ? {
                 transform: 'translateY(-2px)',
                 boxShadow: 6,
               }
             : {},
+          '&:active': isSelectable
+            ? {
+                transform: 'scale(0.97)',
+              }
+            : {},
         }}
       >
-        <Typography variant="body1" align="center" fontWeight="medium">
+        <Typography
+          variant="body1"
+          align="center"
+          fontWeight="medium"
+          sx={{ fontSize: { xs: '0.7rem', sm: '0.875rem' }, px: 0.5 }}
+        >
           {card.word}
         </Typography>
       </Paper>
@@ -268,12 +280,14 @@ const GameBoard = forwardRef(
     };
 
     return (
-      <Paper sx={{ p: 3, mb: 3 }} elevation={3}>
+      <Paper sx={{ p: { xs: 1.5, sm: 3 }, mb: 3 }} elevation={3}>
         <Box
           sx={{
             display: 'flex',
+            flexWrap: 'wrap',
             justifyContent: 'space-between',
             alignItems: 'center',
+            gap: 1,
             mb: 2,
           }}
         >
@@ -281,7 +295,14 @@ const GameBoard = forwardRef(
 
           {/* Show active keyword if one exists */}
           {activeKeyword && (
-            <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+            <Box
+              sx={{
+                display: 'flex',
+                flexWrap: 'wrap',
+                alignItems: 'center',
+                gap: 1,
+              }}
+            >
               <Typography variant="body2">Active Keyword:</Typography>
               <Chip
                 label={activeKeyword.word}
@@ -299,7 +320,12 @@ const GameBoard = forwardRef(
         </Box>
 
         <Box sx={{ mb: 2 }}>
-          <Typography variant="body2" align="center" color="text.secondary">
+          <Typography
+            variant="body2"
+            align="center"
+            color="text.secondary"
+            sx={{ fontSize: { xs: '0.75rem', sm: '0.875rem' } }}
+          >
             {isUserTeamLead
               ? 'As Hacker, you can see the type of each card. Submit keywords to help your team find them.'
               : isUserTurn
@@ -308,7 +334,7 @@ const GameBoard = forwardRef(
           </Typography>
         </Box>
 
-        <Grid container spacing={2}>
+        <Grid container spacing={{ xs: 1, sm: 2 }}>
           {boardData.map((card) => {
             // Get other players who have selected this card (excluding current user)
             const otherPlayersSelections = Object.entries(
@@ -321,7 +347,7 @@ const GameBoard = forwardRef(
               .map(([userId]) => userId);
 
             return (
-              <Grid item xs={3} key={card.id}>
+              <Grid item xs={6} sm={3} key={card.id}>
                 <GameTile
                   card={card}
                   isTeamLead={isUserTeamLead}
@@ -339,7 +365,13 @@ const GameBoard = forwardRef(
         {/* Legend for hackers */}
         {isUserTeamLead && (
           <Box
-            sx={{ mt: 2, display: 'flex', justifyContent: 'center', gap: 2 }}
+            sx={{
+              mt: 2,
+              display: 'flex',
+              flexWrap: 'wrap',
+              justifyContent: 'center',
+              gap: { xs: 1.5, sm: 2 },
+            }}
           >
             <Box sx={{ display: 'flex', alignItems: 'center' }}>
               <Box
@@ -392,7 +424,7 @@ const GameBoard = forwardRef(
           </Box>
         )}
 
-        {/* Submit button for team members */}
+        {/* Submit button for team members — full-width on mobile */}
         {isTeamMember &&
           isUserTurn &&
           activeKeyword &&
@@ -402,8 +434,9 @@ const GameBoard = forwardRef(
                 variant="contained"
                 color={userTeam === TEAMS.TEAM1 ? 'primary' : 'error'}
                 onClick={submitGuesses}
-                // Allow submitting any number up to the count
                 disabled={selectedCards.length > activeKeyword.count}
+                size="large"
+                sx={{ width: { xs: '100%', sm: 'auto' } }}
               >
                 Submit Guess ({selectedCards.length}/{activeKeyword.count})
               </Button>

--- a/frontend/src/components/GameContent.jsx
+++ b/frontend/src/components/GameContent.jsx
@@ -43,9 +43,14 @@ const GameContent = ({ endGame, isUserHost, lobby, user, getCurrentTeam }) => {
   const hostName = hostParticipant?.display_name || 'Unknown';
 
   return (
-    <Box sx={{ mt: 4, mx: 'auto', maxWidth: 800 }}>
-      <Paper sx={{ p: 4, mb: 2 }}>
-        <Typography variant="h4" gutterBottom align="center">
+    <Box sx={{ mt: { xs: 2, sm: 4 }, mx: 'auto', maxWidth: 800 }}>
+      <Paper sx={{ p: { xs: 2, sm: 4 }, mb: 2 }}>
+        <Typography
+          variant="h4"
+          gutterBottom
+          align="center"
+          sx={{ fontSize: { xs: '1.5rem', sm: '2.125rem' } }}
+        >
           Game In Progress
         </Typography>
 

--- a/frontend/src/components/GameStatusIndicator.jsx
+++ b/frontend/src/components/GameStatusIndicator.jsx
@@ -42,7 +42,7 @@ const GameStatusIndicator = ({ lobby }) => {
       </Typography>
 
       <Grid container spacing={2}>
-        <Grid item xs={5}>
+        <Grid item xs={12} sm={5}>
           <Box
             sx={{
               p: 2,
@@ -60,9 +60,17 @@ const GameStatusIndicator = ({ lobby }) => {
           >
             <Typography variant="subtitle1" fontWeight="bold">
               {TEAM_LABELS[TEAMS.TEAM1]}
+              {gameState.activeTeam === TEAMS.TEAM1 && (
+                <Chip
+                  label="Active"
+                  color="primary"
+                  size="small"
+                  sx={{ ml: 1, display: { xs: 'inline-flex', sm: 'none' } }}
+                />
+              )}
             </Typography>
             <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, mt: 1 }}>
-              <Typography>Remaining Cards:</Typography>
+              <Typography variant="body2">Remaining Cards:</Typography>
               <Chip label={team1RemainingCards} color="primary" size="small" />
             </Box>
             <Divider sx={{ width: '100%', my: 1 }} />
@@ -76,9 +84,10 @@ const GameStatusIndicator = ({ lobby }) => {
 
         <Grid
           item
-          xs={2}
+          xs={12}
+          sm={2}
           sx={{
-            display: 'flex',
+            display: { xs: 'none', sm: 'flex' },
             alignItems: 'center',
             justifyContent: 'center',
           }}
@@ -91,7 +100,7 @@ const GameStatusIndicator = ({ lobby }) => {
           </Box>
         </Grid>
 
-        <Grid item xs={5}>
+        <Grid item xs={12} sm={5}>
           <Box
             sx={{
               p: 2,
@@ -109,9 +118,17 @@ const GameStatusIndicator = ({ lobby }) => {
           >
             <Typography variant="subtitle1" fontWeight="bold">
               {TEAM_LABELS[TEAMS.TEAM2]}
+              {gameState.activeTeam === TEAMS.TEAM2 && (
+                <Chip
+                  label="Active"
+                  color="error"
+                  size="small"
+                  sx={{ ml: 1, display: { xs: 'inline-flex', sm: 'none' } }}
+                />
+              )}
             </Typography>
             <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, mt: 1 }}>
-              <Typography>Remaining Cards:</Typography>
+              <Typography variant="body2">Remaining Cards:</Typography>
               <Chip label={team2RemainingCards} color="error" size="small" />
             </Box>
             <Divider sx={{ width: '100%', my: 1 }} />

--- a/frontend/src/components/HackerPrompt.jsx
+++ b/frontend/src/components/HackerPrompt.jsx
@@ -97,7 +97,11 @@ const HackerPrompt = ({ activeTeam, isTeamLead, isTeamTurn }) => {
       </Typography>
 
       <form onSubmit={handleSubmit}>
-        <Stack direction="row" spacing={2} alignItems="flex-start">
+        <Stack
+          direction={{ xs: 'column', sm: 'row' }}
+          spacing={2}
+          alignItems={{ xs: 'stretch', sm: 'flex-start' }}
+        >
           <TextField
             label="Keyword"
             value={word}
@@ -108,10 +112,11 @@ const HackerPrompt = ({ activeTeam, isTeamLead, isTeamTurn }) => {
             size="small"
             placeholder="Enter a single word..."
             helperText="Input a strategic word to help your team find your cards"
+            inputProps={{ autoCapitalize: 'none', autoCorrect: 'off' }}
           />
 
           <FormControl
-            sx={{ minWidth: 120 }}
+            sx={{ minWidth: { xs: '100%', sm: 120 } }}
             size="small"
             disabled={isDisabled}
           >
@@ -135,6 +140,8 @@ const HackerPrompt = ({ activeTeam, isTeamLead, isTeamTurn }) => {
             color={activeTeam === TEAMS.TEAM1 ? 'primary' : 'error'}
             endIcon={<SendIcon />}
             disabled={isDisabled || !word.trim()}
+            size="large"
+            sx={{ flexShrink: 0 }}
           >
             Send
           </Button>

--- a/frontend/src/components/LobbyDetails.jsx
+++ b/frontend/src/components/LobbyDetails.jsx
@@ -1,15 +1,55 @@
 // src/components/LobbyDetails.jsx
-import React from 'react';
-import { Card, CardContent, Typography, Link, Button } from '@mui/material';
+import React, { useState } from 'react';
+import {
+  Card,
+  CardContent,
+  Typography,
+  Link,
+  Button,
+  Box,
+  Snackbar,
+  Alert,
+} from '@mui/material';
+import ShareIcon from '@mui/icons-material/Share';
+import ContentCopyIcon from '@mui/icons-material/ContentCopy';
 import useWebex from '../hooks/useWebex';
 import { useLobbyContext } from '../context/useLobbyContext';
 
 /**
- * Displays key game lobby information and Webex sharing controls.
+ * Displays key game lobby information, Webex sharing controls, and a
+ * mobile-friendly share button using the Web Share API with a clipboard fallback.
  */
 const LobbyDetails = () => {
   const { isShared, isRunningInWebex, toggleShare } = useWebex();
   const { lobby, lobbyUrl } = useLobbyContext();
+  const [copySnackbarOpen, setCopySnackbarOpen] = useState(false);
+
+  const canNativeShare =
+    typeof navigator !== 'undefined' && Boolean(navigator.share);
+
+  const handleShareLobby = async () => {
+    const shareData = {
+      title: `Join ${lobby?.lobby_name || 'Game Lobby'} — Lockout`,
+      text: `Join my Lockout game "${lobby?.lobby_name || 'Game Lobby'}"!`,
+      url: lobbyUrl,
+    };
+
+    if (canNativeShare) {
+      try {
+        await navigator.share(shareData);
+      } catch {
+        // User cancelled the share sheet — no action needed
+      }
+    } else {
+      // Clipboard fallback for desktop browsers
+      try {
+        await navigator.clipboard.writeText(lobbyUrl);
+        setCopySnackbarOpen(true);
+      } catch {
+        // Clipboard write failed — nothing we can do silently
+      }
+    }
+  };
 
   return (
     <Card sx={{ mb: 3 }}>
@@ -20,12 +60,26 @@ const LobbyDetails = () => {
         <Typography variant="body2" color="textSecondary">
           Game ID: {lobby?.id}
         </Typography>
-        <Typography variant="body2">
+        <Typography variant="body2" sx={{ wordBreak: 'break-all' }}>
           Game URL:{' '}
           <Link href={lobbyUrl} target="_blank" rel="noopener noreferrer">
             {lobbyUrl}
           </Link>
         </Typography>
+
+        {/* Mobile-friendly share button */}
+        <Box sx={{ mt: 2 }}>
+          <Button
+            variant="contained"
+            color="secondary"
+            onClick={handleShareLobby}
+            startIcon={canNativeShare ? <ShareIcon /> : <ContentCopyIcon />}
+            fullWidth
+            data-testid="share-lobby-button"
+          >
+            {canNativeShare ? 'Share Lobby' : 'Copy Lobby Link'}
+          </Button>
+        </Box>
 
         <Typography variant="body1" sx={{ mt: 2 }}>
           <strong>Lobby Sharing:</strong>{' '}
@@ -52,6 +106,21 @@ const LobbyDetails = () => {
           </Typography>
         )}
       </CardContent>
+
+      <Snackbar
+        open={copySnackbarOpen}
+        autoHideDuration={3000}
+        onClose={() => setCopySnackbarOpen(false)}
+        anchorOrigin={{ vertical: 'bottom', horizontal: 'center' }}
+      >
+        <Alert
+          onClose={() => setCopySnackbarOpen(false)}
+          severity="success"
+          sx={{ width: '100%' }}
+        >
+          Lobby link copied to clipboard!
+        </Alert>
+      </Snackbar>
     </Card>
   );
 };

--- a/playwright.config.js
+++ b/playwright.config.js
@@ -40,6 +40,16 @@ export default defineConfig({
       name: 'chromium',
       use: { ...devices['Desktop Chrome'] },
     },
+    {
+      name: 'mobile-chrome',
+      use: { ...devices['Pixel 5'] },
+      testMatch: '**/mobile-game.spec.js',
+    },
+    {
+      name: 'mobile-safari',
+      use: { ...devices['iPhone 12'] },
+      testMatch: '**/mobile-game.spec.js',
+    },
   ],
 
   // Automatically start (and stop) both servers before (and after) the suite.


### PR DESCRIPTION
- GameBoard: 2-column responsive grid on mobile (xs=6/sm=3), shorter
  cards (56px mobile / 80px desktop), touch-action manipulation, smaller
  font, full-width submit button on mobile, wrapping keyword/legend areas
- HackerPrompt: stack keyword input, card-count select, and send button
  vertically on mobile (xs=column / sm=row); disable autocorrect on keyword input
- GameContent: responsive padding (2 mobile / 4 desktop) and heading font size
- GameStatusIndicator: teams stack full-width (xs=12/sm=5) on mobile with
  inline "Active" chip; hide arrow indicator below sm breakpoint
- LobbyDetails: new "Share Lobby" button using Web Share API on mobile,
  clipboard copy fallback on desktop with Snackbar confirmation; uses
  data-testid="share-lobby-button" for test targeting
- playwright.config.js: add mobile-chrome (Pixel 5) and mobile-safari
  (iPhone 12) Playwright projects scoped to mobile-game.spec.js
- e2e/mobile-game.spec.js: three new mobile test suites —
  (1) share button renders and copies to clipboard,
  (2) board renders in 2-column layout on mobile viewport,
  (3) full 4-player game completed with tap() interactions on mobile

https://claude.ai/code/session_01LXbcxBMq954kuGguFgnUzX